### PR TITLE
Fix/pycrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dependencies:
 - Python 3
 - requests
 - requests-toolbelt
-- pycrypto
+- pycryptodome
 - clint (optional)
 
 ## Tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 requests-toolbelt
-pycrypto
+pycryptodome
 clint

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ VERSION = '0.1'
 install_requires = [
     'requests',
     'requests-toolbelt',
-    'pycrypto',
+    'pycryptodome',
     'clint',
 ]
 


### PR DESCRIPTION
One of the dependencies pyCrypto is outdated:
https://www.pycrypto.org/

It also fails to compile locally. This fix uses pyCryptodome instead, which is a drop in replacement.